### PR TITLE
fix end of line in the doc for neovim configuration

### DIFF
--- a/source/exegol-image/my-resources.rst
+++ b/source/exegol-image/my-resources.rst
@@ -148,6 +148,7 @@ Exegol supports overwriting its **vim** configuration to allow all users to use 
     Will be available from version ``3.1.2`` of any exegol image.
 
 Exegol supports overwriting its **neovim** configuration to allow all users to use their personal configuration.
+
 * To automatically overwrite the ``~/.config/nvim/`` configuration, copy your config in  ``/opt/my-resources/setup/nvim/``
 
 .. tip::


### PR DESCRIPTION
missing end of line 
![image](https://github.com/Neptunium931/Exegol-docs/assets/62119053/d7faaa90-2833-42a6-a868-f83d4fc872d3)